### PR TITLE
Close tasks channel after WaitGroup.Wait

### DIFF
--- a/workerpool.go
+++ b/workerpool.go
@@ -143,7 +143,7 @@ func (wp *WorkerPool) Close() error {
 		return nil
 	}
 	wp.closed = true
-	close(wp.tasks)
 	wp.wg.Wait()
+	close(wp.tasks)
 	return nil
 }


### PR DESCRIPTION
We could potentially run into an issue with writing to `WorkerPool.tasks`
in case the channel is closed concurrently:

```
  goroutine 1:                         goroutine 2:
   Submit                               Close
    -> wp.wg.Add(1)
    -> scheduled by runtime
                                        -> close(wp.tasks)
                                        -> scheduled by runtime
    -> wp.tasks <- &task{...}
    -> panic: write to closed channel
```

The situation can be provoked in some cases using the following test:

```go
func TestSubmitCloseConcurrent(t *testing.T) {
       n := runtime.NumCPU()
       wp := New(n)
       for i := 0; i < n+2; i++ {
               go func() {
                       _ = wp.Submit("", func() error {
                               time.Sleep(time.Millisecond)
                               return nil
                       })
               }()
       }
       wp.Close()
}
```

Avoid the panic case by closing the tasks channel after waiting for the
`WaitGroup`.

The reproducing test is not added yet, as there seem to be other
concurrency issues present which the test triggers.