### PR TITLE
Test Drain on already drained worker pool

### DIFF
--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -196,11 +196,19 @@ func TestConcurrentDrain(t *testing.T) {
 		<-done
 	}
 
+	wg.Wait()
+
+	results, err = wp.Drain()
+	if err != nil {
+		t.Errorf("drain: got '%v', want '%v'", err, nil)
+	}
+	if len(results) != 0 {
+		t.Errorf("drain: unexpectedly got '%d' results", len(results))
+	}
+
 	if err := wp.Close(); err != nil {
 		t.Errorf("close: got '%v', want no error", err)
 	}
-
-	wg.Wait()
 }
 
 func TestWorkerPoolCap(t *testing.T) {


### PR DESCRIPTION
Test that calling `(*WorkerPool).Drain` on an already drained pool returns
no error an an empty results slice.