### PR TITLE
.github: use matrix strategy and test with Go 1.15 as well

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,15 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        go-version: [1.15.8, 1.16.0]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
       uses: actions/setup-go@v2.1.3
       with:
-        go-version: '1.16.0'
+        go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Format


### PR DESCRIPTION
Test on Go 1.15 as well, given it is still officially
supported (as per https://golang.org/doc/devel/release.html#policy),
go.mod states go1.15 and we use no Go 1.16 specific features.