### PR TITLE
doc: remove experimental warning in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ Package workerpool implements a concurrency limiting worker pool. Worker
 routines are spawned on demand as tasks are submitted.
 
 This package is mostly useful when tasks are CPU bound and spawning too many
-routines would be detrimental to performances.
-
-**WARNING**: The API is still experimental and subject to change.
+routines would be detrimental to performance. It features a straightforward API
+and no external dependencies. See the section below for a usage example.
 
 ## Example
 


### PR DESCRIPTION
We have experimented enough with this API to deem it stable enough for a v1.0 release.