### PR TITLE
Run staticcheck as part of CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Format
+      if: matrix.go-version >= '1.16'
       run: test -z $(gofmt -l .)
     - name: Build
       run: go build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,5 +30,11 @@ jobs:
       run: go build
     - name: Vet
       run: go vet
+    - name: Install and run staticcheck
+      if: matrix.go-version >= '1.16'
+      run: |
+        go install honnef.co/go/tools/cmd/staticcheck@v0.1.2
+        staticcheck -version
+        staticcheck -- ./...
     - name: Run unit tests
       run: go test -v -race -cover


### PR DESCRIPTION
Use `go install` behavior in Go 1.16 to get `staticcheck` whithout having to add it as a package dependency.

Also run `gofmt` only with Go 1.16. In the past there occasionally have been changes in `gofmt` behavior between Go versions. In order to avoid these, only run `gofmt` from the latest Go version, i.e. currently Go 1.16.