### PR TITLE
.github: show diff when gofmt check fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Format
       if: matrix.go-version >= '1.16'
-      run: test -z $(gofmt -l .)
+      run: diff -u <(echo -n) <(gofmt -d .)
     - name: Build
       run: go build
     - name: Vet


### PR DESCRIPTION
Rather than just failing the check, also show the diff.