### PR TITLE
Move tests into a separate package

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,22 @@
+// Copyright 2021 Authors of Cilium
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workerpool
+
+// export for testing only
+
+// TasksCap returns the tasks channel capacity.
+func (wp *WorkerPool) TasksCap() int {
+	return cap(wp.tasks)
+}


### PR DESCRIPTION
Moving the test code out of the `workerpool` package allows to write
tests from the perspective of a real user of the package. We cannot
possibly fiddle around with internals and keep tests focussed on the
exposed API.

Currently, there's still one case where we want to check internal state:
the `(*WorkerPool).tasks` capacity check. For that, export a
`(*WorkerPool).TasksCap` method for testing only.