### PR TITLE
.github: run tests on Go 1.17

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.15.11, 1.16.3]
+        go-version: [1.16, 1.17]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
@@ -24,14 +24,14 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Format
-      if: matrix.go-version >= '1.16'
+      if: matrix.go-version >= '1.17'
       run: diff -u <(echo -n) <(gofmt -d .)
     - name: Build
       run: go build
     - name: Vet
       run: go vet
     - name: Install and run staticcheck
-      if: matrix.go-version >= '1.16'
+      if: matrix.go-version >= '1.17'
       run: |
         go install honnef.co/go/tools/cmd/staticcheck@latest
         staticcheck -version


### PR DESCRIPTION
Also drop 1.15.11 from test matrix and always use the latest minor
release.