### PR TITLE
Avoid crash when running task with (*task).run == nil

### DIFF
--- a/workerpool.go
+++ b/workerpool.go
@@ -182,7 +182,9 @@ func (wp *WorkerPool) run(ctx context.Context) {
 		wp.workers <- struct{}{}
 		go func() {
 			defer wp.wg.Done()
-			result.err = t.run(ctx)
+			if t.run != nil {
+				result.err = t.run(ctx)
+			}
 			<-wp.workers
 		}()
 	}

--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -330,6 +330,30 @@ func TestWorkerPoolDrainAfterClose(t *testing.T) {
 	}
 }
 
+func TestWorkerPoolSubmitNil(t *testing.T) {
+	wp := workerpool.New(runtime.NumCPU())
+	defer wp.Close()
+	id := "nothing"
+	if err := wp.Submit(id, nil); err != nil {
+		t.Fatalf("got %v; want no error", err)
+	}
+	tasks, err := wp.Drain()
+	if err != nil {
+		t.Errorf("got %v; want no error", err)
+	}
+	if n := len(tasks); n != 1 {
+		t.Errorf("got %v tasks; want 1", n)
+	}
+	r := tasks[0]
+	if s := r.String(); s != id {
+		t.Errorf("String: got '%s', want '%s'", s, id)
+	}
+	if err := r.Err(); err != nil {
+		t.Errorf("Err: got '%v', want no error", err)
+	}
+
+}
+
 func TestWorkerPoolSubmitAfterClose(t *testing.T) {
 	wp := workerpool.New(runtime.NumCPU())
 	wp.Close()


### PR DESCRIPTION
The following program currently leads to a crash due to nil pointer
dereference:

	wp := workerpool.New(runtime.NumCPU())
	defer wp.Close()
	if err := wp.Submit("foobar", nil); err != nil {
		panic(err)
	}
	tasks, err := wp.Drain()

Fix this by checking (*task).run before running it. This way we keep the
semantics of returning a result for every submitted task. The
alternative solution would be to not enqueue the task on
(*WorkerPool).Submit("foobar", nil) and return either nil or an error.
Both would lead to an imbalance between bumber of submitted tasks and
returned results.