### PR TITLE
Wait for worker to be submitted in TestWorkerPoolLen

### DIFF
--- a/workerpool_test.go
+++ b/workerpool_test.go
@@ -78,7 +78,9 @@ func TestWorkerPoolLen(t *testing.T) {
 		t.Errorf("got %d; want %d", l, 0)
 	}
 
+	submitted := make(chan struct{})
 	err := wp.Submit("", func(ctx context.Context) error {
+		close(submitted)
 		<-ctx.Done()
 		return ctx.Err()
 	})
@@ -86,6 +88,7 @@ func TestWorkerPoolLen(t *testing.T) {
 		t.Fatalf("failed to submit task: %v", err)
 	}
 
+	<-submitted
 	if l := wp.Len(); l != 1 {
 		t.Errorf("got %d; want %d", l, 1)
 	}


### PR DESCRIPTION
Occasionally, TestWorkerPoolLen will fail with:

=== RUN   TestWorkerPoolLen
    workerpool_test.go:90: got 0; want 1
--- FAIL: TestWorkerPoolLen (0.00s)

see e.g. https://github.com/cilium/workerpool/runs/5717463554?check_suite_focus=true

This seems to happen more often since switching to Go 1.18.

Fix this by waiting for the worker to be submitted before checking
(*WorkerPool).Len.