### PR TITLE
ci: enable more golangci-lint checkers, update config for Go 1.18

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Run static checks
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
         version: v1.45.2
         args: --config=.golangci.yml --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,8 +5,13 @@ linters:
   disable-all: true
   enable:
     - asciicheck
+    - bidichk
+    - bodyclose
+    - containedctx
+    - cyclop
     - deadcode
     - dogsled
+    - dupl
     - durationcheck
     - errcheck
     - errname
@@ -14,39 +19,52 @@ linters:
     - exhaustive
     - exportloopref
     - forcetypeassert
+    - gocognit
+    - goconst
+    - gocritic
     - godot
     - goerr113
     - gofmt
     - goimports
+    - gomnd
     - gosec
     - gosimple
     - govet
+    - grouper
     - ifshort
     - ineffassign
+    - ireturn
+    - makezero
     - misspell
     - nestif
     - nilerr
+    - nilnil
     - prealloc
     - predeclared
     - revive
     - rowserrcheck
     - staticcheck
     - structcheck
+    - tenv
     - thelper
+    - tparallel
     - typecheck
     - unconvert
     - unparam
     - unused
     - varcheck
+    - wastedassign
 
 linters-settings:
+  cyclop:
+    skip-tests: true
   gosimple:
-    go: "1.17"
+    go: "1.18"
   govet:
     enable-all: true
   staticcheck:
-    go: "1.17"
+    go: "1.18"
   stylecheck:
-    go: "1.17"
+    go: "1.18"
   unused:
-    go: "1.17"
+    go: "1.18"


### PR DESCRIPTION
Commit 3f5cb13ba7dd12398c07192996e4fcaaa8bc3d68 updated CI for Go 1.18 as well as the version of golangci-lint. However, it omitted updating the golangci-lint configuration to default for Go 1.18 instead of Go 1.17. This commit does this and also enables more checkers.

This commit also updated the golangci-lint action configuration for v3 without actually updating the action version itself, which prevents it from running. This issue is addressed in the first commit of this PR.