### PR TITLE
add NewWithContext

### DIFF
--- a/workerpool.go
+++ b/workerpool.go
@@ -50,6 +50,12 @@ type WorkerPool struct {
 // New creates a new pool of workers where at most n workers process submitted
 // tasks concurrently. New panics if n ≤ 0.
 func New(n int) *WorkerPool {
+	return NewWithContext(context.Background(), n)
+}
+
+// NewWithContext creates a new pool of workers where at most n workers process submitted
+// tasks concurrently. New panics if n ≤ 0. The context is used as the parent context to the context of the task func passed to Submit.
+func NewWithContext(ctx context.Context, n int) *WorkerPool {
 	if n <= 0 {
 		panic(fmt.Sprintf("workerpool.New: n must be > 0, got %d", n))
 	}
@@ -57,7 +63,7 @@ func New(n int) *WorkerPool {
 		workers: make(chan struct{}, n),
 		tasks:   make(chan *task),
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	wp.cancel = cancel
 	go wp.run(ctx)
 	return wp


### PR DESCRIPTION
Before this patch, forwarding context cancellation to the workerpool tasks was difficult and required to spawn a goroutine to call `wp.Close` when the parent context was done.

This patch introduce `NewWithContext` allowing callers to provide a parent context from which is derived the tasks context, removing the need to manually forward context cancellation.
