### PR TITLE
ci: update golangci-lint to v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,12 +24,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - name: Run static checks
-      uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84
+      uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd
       with:
-        version: v1.64.5
-        # use our .golangci.yml and configure output to be logged in the GHA, in addition to annotating the commit.
-        # see https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648 for output
-        args: --config=.golangci.yml --verbose --out-${NO_FUTURE}format colored-line-number --timeout 5m
+        version: v2.0.1
+        # use our .golangci.yml
+        args: --config=.golangci.yml --verbose
         skip-cache: true
     - name: Build
       run: go build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,9 @@
 # See https://golangci-lint.run/usage/configuration/ for available options.
 # Also https://github.com/cilium/cilium/blob/main/.golangci.yaml as a
 # reference.
-run:
-  timeout: 1m
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -23,20 +22,17 @@ linters:
     - errcheck
     - errname
     - errorlint
-    - exptostd
     - exhaustive
+    - exptostd
     - forcetypeassert
     - gocheckcompilerdirectives
     - gocognit
     - goconst
     - gocritic
     - godot
-    - gofmt
     - goheader
-    - goimports
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - grouper
     - ineffassign
@@ -65,34 +61,36 @@ linters:
     - testifylint
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
     - usestdlibvars
     - usetesting
     - wastedassign
-linters-settings:
-  cyclop:
-    skip-tests: true
-  goheader:
-    template: |-
-      SPDX-License-Identifier: Apache-2.0
-      Copyright Authors of Cilium
-  govet:
-    enable-all: true
-  perfsprint:
-    strconcat: false
-  sloglint:
-    no-mixed-args: true
-    static-msg: true
-    no-global: "all"
-    key-naming-case: kebab # be consistent with key names
-    forbidden-keys: # let's no use reserved log keys
-      - level
-      - msg
-      - source
-      - time
+  settings:
+    goheader:
+      template: |-
+        SPDX-License-Identifier: Apache-2.0
+        Copyright Authors of Cilium
+    govet:
+      enable-all: true
+    perfsprint:
+      strconcat: false
+    sloglint:
+      no-mixed-args: true
+      static-msg: true
+      no-global: "all"
+      key-naming-case: kebab # be consistent with key names
+      forbidden-keys: # let's no use reserved log keys
+        - level
+        - msg
+        - source
+        - time
+  exclusions:
+    rules:
+      - linters:
+          - cyclop
+        path: (.+)_test\.go
 issues:
   # Maximum issues count per one linter.
   # Set to 0 to disable (default is 50)
@@ -101,5 +99,7 @@ issues:
   # Set to 0 to disable (default is 3)
   max-same-issues: 0
   fix: true # fix found issues (if it's supported by the linter).
-  exclude-use-default: false # default rules exclude doc comments check :(
-  exclude-generated: strict
+formatters:
+  enable:
+    - gofmt
+    - goimports


### PR DESCRIPTION
Required bump of golangci/golangci-lint-action to v7.0.0 on the way.